### PR TITLE
Update to go1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM golang:1.17
+FROM golang:1.18
 
 ENV GO111MODULE=on
 
 RUN apt-get update && \
 	apt-get -y install jq && \
-	go get -u \
-		github.com/kisielk/errcheck \
-		golang.org/x/tools/cmd/goimports \
-		golang.org/x/lint/golint \
-		github.com/securego/gosec/cmd/gosec \
-		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
-		honnef.co/go/tools/cmd/staticcheck
+	go install github.com/kisielk/errcheck@latest && \
+	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install golang.org/x/lint/golint@latest && \
+	go install github.com/securego/gosec/cmd/gosec@latest && \
+	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Related issues

Github actions that use this image are failing.

## Description

This change ups the Go version used in this image to 1.18 and changes the `go get` commands for tools to `go install`.

## Checklist
Before requesting reviews, check all boxes below.

- [x] I have left self-review comments to help other reviewers.
- [x] My PR is as small as possible and focused on a single task.md#api-checklist).
- [x] I have considered and implemented security best practices
- [x] If tagging multiple reviewers, I have made specific asks.

## Manual testing
Before marking as "ready for production", check all boxes below.

## Production readiness
Before merging, "ready" should be checked.

- [ ] WIP: it's not ready for review
- [ ] Pending: it's not ready for production
- [x] Ready: it's ready for production
