### PR TITLE
Temp: Use local version of gosec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update && \
 	go install github.com/kisielk/errcheck@latest && \
 	go install golang.org/x/tools/cmd/goimports@latest && \
 	go install golang.org/x/lint/golint@latest && \
-	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
 	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
 	go install honnef.co/go/tools/cmd/staticcheck@latest
+
+# Manually install a patched version of gosec
+RUN git clone https://github.com/convictional/gosec && cd gosec && go install . && cd ..
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This change modifies the dockerfile to build gosec from a forked copy of gosec located in https://github.com/convictional/gosec.

The version located there has had it's go/tools package version bumped to avoid an issue detailed here: https://github.com/golang/go/issues/51629. A PR to fix it upstream is here: https://github.com/securego/gosec/pull/817