### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 # Manually install a patched version of gosec
-RUN git clone https://github.com/convictional/gosec && cd gosec && go install . && cd ..
+RUN git clone https://github.com/convictional/gosec && cd gosec && go install ./cmd/gosec/ && cd ..
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Related issues

## Description

This change fixes a line in the docker build that mistakenly installs the root package for gosec.

## Checklist
Before requesting reviews, check all boxes below.

- [ ] I have left self-review comments to help other reviewers.
- [ ] My PR is as small as possible and focused on a single task.md#api-checklist).
- [ ] I have considered and implemented security best practices
- [ ] If tagging multiple reviewers, I have made specific asks.

## Manual testing
Before marking as "ready for production", check all boxes below.

- [ ] List all the verification steps you'll perform here (at least one)

## Production readiness
Before merging, "ready" should be checked.

- [ ] WIP: it's not ready for review
- [ ] Pending: it's not ready for production
- [x] Ready: it's ready for production
